### PR TITLE
Raise import errors only when libopenslide/libvips are actually needed

### DIFF
--- a/panimg/exceptions.py
+++ b/panimg/exceptions.py
@@ -16,3 +16,22 @@ class UnconsumedFilesException(Exception):
     def __init__(self, *args, file_errors: Dict[Path, List[str]]):
         super().__init__(*args)
         self.file_errors = file_errors
+
+
+class MissingLibraryException(RuntimeError):
+    pass
+
+
+class MissingLibraryMockModule:
+    """
+    Replaces a module that is not working due to a missing external
+    dependency (such as OpenSlide) and raises an exception as soon as
+    the module is used for the first time (i.e., when an object in the
+    module is accessed).
+    """
+
+    def __init__(self, *args):
+        self.args = args
+
+    def __getattr__(self, item):
+        raise MissingLibraryException(*self.args)

--- a/panimg/exceptions.py
+++ b/panimg/exceptions.py
@@ -22,7 +22,7 @@ class MissingLibraryException(RuntimeError):
     pass
 
 
-class MissingLibraryMockModule:
+class DeferredMissingLibraryException:
     """
     Replaces a module that is not working due to a missing external
     dependency (such as OpenSlide) and raises an exception as soon as

--- a/panimg/image_builders/tiff.py
+++ b/panimg/image_builders/tiff.py
@@ -7,15 +7,31 @@ from tempfile import TemporaryDirectory
 from typing import Callable, DefaultDict, Dict, Iterator, List, Optional, Set
 from uuid import UUID, uuid4
 
-import openslide
-import pyvips
 import tifffile
 
-from panimg.exceptions import UnconsumedFilesException, ValidationError
+from panimg.exceptions import (
+    MissingLibraryMockModule,
+    UnconsumedFilesException,
+    ValidationError,
+)
 from panimg.models import (
     ColorSpace,
     TIFFImage,
 )
+
+try:
+    import openslide
+except OSError:
+    openslide = MissingLibraryMockModule(
+        "libopenslide is not installed on the system"
+    )
+
+try:
+    import pyvips
+except OSError:
+    pyvips = MissingLibraryMockModule(
+        "libslide is not installed on the system"
+    )
 
 
 @dataclass

--- a/panimg/image_builders/tiff.py
+++ b/panimg/image_builders/tiff.py
@@ -10,7 +10,7 @@ from uuid import UUID, uuid4
 import tifffile
 
 from panimg.exceptions import (
-    MissingLibraryMockModule,
+    DeferredMissingLibraryException,
     UnconsumedFilesException,
     ValidationError,
 )
@@ -22,14 +22,14 @@ from panimg.models import (
 try:
     import openslide
 except OSError:
-    openslide = MissingLibraryMockModule(
+    openslide = DeferredMissingLibraryException(
         "libopenslide is not installed on the system"
     )
 
 try:
     import pyvips
 except OSError:
-    pyvips = MissingLibraryMockModule(
+    pyvips = DeferredMissingLibraryException(
         "libslide is not installed on the system"
     )
 

--- a/panimg/image_builders/tiff.py
+++ b/panimg/image_builders/tiff.py
@@ -30,7 +30,7 @@ try:
     import pyvips
 except OSError:
     pyvips = DeferredMissingLibraryException(
-        "libslide is not installed on the system"
+        "libvips is not installed on the system"
     )
 
 

--- a/panimg/post_processors/tiff_to_dzi.py
+++ b/panimg/post_processors/tiff_to_dzi.py
@@ -1,8 +1,7 @@
 import logging
 from typing import Set
 
-import pyvips
-
+from panimg.exceptions import DeferredMissingLibraryException
 from panimg.models import (
     ImageType,
     PanImgFile,
@@ -10,6 +9,13 @@ from panimg.models import (
     PostProcessorResult,
 )
 from panimg.settings import DZI_TILE_SIZE
+
+try:
+    import pyvips
+except OSError:
+    pyvips = DeferredMissingLibraryException(
+        "libvips is not installed on the system"
+    )
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
An attempt to fix #20 

If the underlying libraries are not installed, importing the openslide or pyvips modules fails. This PR replaces the module with a mock module that raises an exception only when the module is actually used.