### PR TITLE
Avoid division by zero when computing slice spacing when there is only one slice

### DIFF
--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -204,7 +204,7 @@ def _process_dicom_file(*, dicom_ds):  # noqa: C901
     content_times = []
     exposures = []
     origin = None
-    origin_diff = np.array((0, 0, 0), dtype=float)
+    origin_diff = 0
     n_diffs = 0
     for partial in dicom_ds.headers:
         ds = partial["data"]
@@ -215,11 +215,14 @@ def _process_dicom_file(*, dicom_ds):  # noqa: C901
                 origin_diff = origin_diff + diff
                 n_diffs += 1
             origin = file_origin
-    avg_origin_diff = tuple(origin_diff / n_diffs)
-    try:
-        z_i = avg_origin_diff[2]
-    except IndexError:
-        z_i = 1.0
+    if n_diffs == 0:
+        z_i = np.nan
+    else:
+        avg_origin_diff = tuple(origin_diff / n_diffs)
+        try:
+            z_i = avg_origin_diff[2]
+        except IndexError:
+            z_i = 1.0
 
     samples_per_pixel = int(getattr(ref_file, "SamplesPerPixel", 1))
     img = _create_itk_from_dcm(

--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -204,7 +204,7 @@ def _process_dicom_file(*, dicom_ds):  # noqa: C901
     content_times = []
     exposures = []
     origin = None
-    origin_diff = 0
+    origin_diff = np.array((0, 0, 0), dtype=float)
     n_diffs = 0
     for partial in dicom_ds.headers:
         ds = partial["data"]

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -60,6 +60,19 @@ def test_validate_dicom_files():
             ]
 
 
+def test_image_builder_dicom_single_slice(tmpdir):
+    files = {DICOM_DIR / "1.dcm"}
+    result = _build_files(
+        builder=image_builder_dicom, files=files, output_directory=tmpdir
+    )
+    assert result.consumed_files == files
+    assert len(result.new_images) == 1
+
+    image = result.new_images.pop()
+    assert image.depth == 1
+    assert pytest.approx(image.voxel_depth_mm, 1.0)
+
+
 def test_image_builder_dicom_4dct(tmpdir):
     files = {Path(d[0]).joinpath(f) for d in os.walk(DICOM_DIR) for f in d[2]}
     result = _build_files(


### PR DESCRIPTION
The DICOM image builder iterates over all slices and computes the difference in slice origin between consecutive slices, and finally averages those to determine the slice spacing. This leads to a division by zero when there is only one slice, which does not cause any problems but results in a RuntimeWarning. This PR adds a check to avoid this warning and a test for reading a single slice.