### PR TITLE
Move matrix manipulations from oct.py to fds and fda functions

### DIFF
--- a/panimg/contrib/oct_converter/readers/fda.py
+++ b/panimg/contrib/oct_converter/readers/fda.py
@@ -140,5 +140,6 @@ class FDA:
             number_pixels = fundus_header.width * fundus_header.height * 3
             raw_image = f.read(fundus_header.size)
             image = decode(raw_image)
+            image = image[:, :, ::-1]
         fundus_image = FundusImageWithMetaData(image)
         return fundus_image

--- a/panimg/contrib/oct_converter/readers/fds.py
+++ b/panimg/contrib/oct_converter/readers/fds.py
@@ -139,6 +139,6 @@ class FDS:
                 3, fundus_header.width, fundus_header.height, order="F"
             )
             image = np.transpose(image, [2, 1, 0])
-            image = image.astype(np.float32)
+            image = image[:, :, ::-1]
         fundus_image = FundusImageWithMetaData(image)
         return fundus_image

--- a/panimg/image_builders/oct.py
+++ b/panimg/image_builders/oct.py
@@ -57,13 +57,11 @@ def _create_itk_images(
         )
     for image in fundus_images:
         eye_choice = LATERALITY_TO_EYE_CHOICE[image.laterality]
+        img_array = image.image
 
         if file.suffix != ".e2e":
-            img_array = image.image.astype(np.uint8)
-            img_array = img_array[:, :, ::-1]
             is_vector = True
         else:
-            img_array = image.image
             is_vector = False
 
         yield _create_itk_fundus_image(


### PR DESCRIPTION
- Deleted unnecessary type conversion from fds function (and oct.py consequently).
- Moved the color axis inversion from oct.py to fds and fda functions. 