### PR TITLE
Add click cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ result = convert(
 )
 ```
 
+### Command Line Interface
+
+`panimg` is also accessible from the command line.
+Install the package from pip as before, then you can use:
+
+**NOTE: Alpha software, do not run this on folders you do not have a backup of.**
+
+```shell
+panimg convert /path/to/files/ /where/files/will/go/
+```
+
+To access the help test you can use `panimg -h`.
+
 ### Supported Formats
 
 | Input                               | Output  | Strategy   | Notes                      |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Under the hood we use:
 
 ## Usage
 
-`panimg` takes a folder full of files and tries to covert them to MHA or TIFF.
+`panimg` takes a folder and tries to covert the containing files to MHA or TIFF.
 For each subdirectory of files it will try several strategies for loading the contained files, and if an image is found it will output it to the output folder.
 It will return a structure containing information about what images were produced, what images were used to form the new images, image metadata, and any errors from any of the strategies.
 

--- a/panimg/__init__.py
+++ b/panimg/__init__.py
@@ -6,4 +6,3 @@ from .panimg import convert
 
 __all__ = ["convert"]
 logger = logging.getLogger(__name__)
-

--- a/panimg/__init__.py
+++ b/panimg/__init__.py
@@ -1,5 +1,9 @@
 __version__ = "0.2.2"
 
+import logging
+
 from .panimg import convert
 
 __all__ = ["convert"]
+logger = logging.getLogger(__name__)
+

--- a/panimg/cli.py
+++ b/panimg/cli.py
@@ -6,7 +6,6 @@ import click
 from panimg import __version__, convert, logger
 
 
-
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.version_option(__version__, "-v", "--version")
 def cli():
@@ -14,7 +13,7 @@ def cli():
 
 
 @cli.command(name="convert", short_help="Convert a directory of image files")
-@click.option('-v', '--verbose', count=True)
+@click.option("-v", "--verbose", count=True)
 @click.argument(
     "input",
     type=click.Path(

--- a/panimg/cli.py
+++ b/panimg/cli.py
@@ -1,8 +1,10 @@
+import logging
 from pathlib import Path
 
 import click
 
-from panimg import __version__, convert
+from panimg import __version__, convert, logger
+
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
@@ -11,7 +13,8 @@ def cli():
     pass
 
 
-@cli.command(name="convert", short_help="Convert a directory")
+@cli.command(name="convert", short_help="Convert a directory of image files")
+@click.option('-v', '--verbose', count=True)
 @click.argument(
     "input",
     type=click.Path(
@@ -34,9 +37,23 @@ def cli():
         resolve_path=True,
     ),
 )
-def convert_cli(input: str, output: str):
+def convert_cli(input: str, output: str, verbose: int):
     input_directory = Path(input)
     output_directory = Path(output)
+
+    ch = logging.StreamHandler()
+
+    if verbose == 0:
+        logger.setLevel(logging.WARNING)
+        ch.setLevel(logging.WARNING)
+    elif verbose == 1:
+        logger.setLevel(logging.INFO)
+        ch.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.DEBUG)
+        ch.setLevel(logging.DEBUG)
+
+    logger.addHandler(ch)
 
     if output_directory.exists():
         raise click.exceptions.UsageError(

--- a/panimg/cli.py
+++ b/panimg/cli.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import click
+
+from panimg import __version__, convert
+
+
+@click.group(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.version_option(__version__, "-v", "--version")
+def cli():
+    pass
+
+
+@cli.command(name="convert", short_help="Convert a directory")
+@click.argument(
+    "input",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        writable=False,
+        resolve_path=True,
+    ),
+)
+@click.argument(
+    "output",
+    type=click.Path(
+        exists=False,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        writable=True,
+        resolve_path=True,
+    ),
+)
+def convert_cli(input: str, output: str):
+    input_directory = Path(input)
+    output_directory = Path(output)
+
+    if output_directory.exists():
+        raise click.exceptions.UsageError(
+            f"Output directory {output_directory} already exists"
+        )
+    else:
+        output_directory.mkdir(parents=True)
+
+    convert(input_directory=input_directory, output_directory=output_directory)

--- a/panimg/panimg.py
+++ b/panimg/panimg.py
@@ -33,7 +33,7 @@ def convert(
 
     builders = builders if builders is not None else DEFAULT_IMAGE_BUILDERS
 
-    builder_names = ", ".join(b.__name__ for b in builders)
+    builder_names = ", ".join(str(b) for b in builders)
     logger.info(f"Using builders {builder_names}")
 
     _convert_directory(
@@ -107,9 +107,7 @@ def _convert_directory(
         if len(builder_files) == 0:
             return
 
-        logger.debug(
-            f"Processing {len(builder_files)} file(s) with {builder.__name__}"
-        )
+        logger.debug(f"Processing {len(builder_files)} file(s) with {builder}")
 
         builder_result = _build_files(
             builder=builder,
@@ -124,11 +122,11 @@ def _convert_directory(
 
         if builder_result.consumed_files:
             logger.info(
-                f"{builder.__name__} created {len(builder_result.new_images)} "
+                f"{builder} created {len(builder_result.new_images)} "
                 f"new images(s) from {len(builder_result.consumed_files)} file(s)"
             )
         else:
-            logger.debug(f"No files consumed by {builder.__name__}")
+            logger.debug(f"No files consumed by {builder}")
 
         for filepath, errors in builder_result.file_errors.items():
             file_errors[filepath].extend(errors)

--- a/panimg/panimg.py
+++ b/panimg/panimg.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import DefaultDict, Dict, Iterable, List, Optional, Set
@@ -14,6 +15,8 @@ from panimg.models import (
 from panimg.post_processors import DEFAULT_POST_PROCESSORS
 from panimg.types import ImageBuilder, PostProcessor
 
+logger = logging.getLogger(__name__)
+
 
 def convert(
     *,
@@ -28,10 +31,15 @@ def convert(
     consumed_files: Set[Path] = set()
     file_errors: DefaultDict[Path, List[str]] = defaultdict(list)
 
+    builders = builders if builders is not None else DEFAULT_IMAGE_BUILDERS
+
+    builder_names = ", ".join(b.__name__ for b in builders)
+    logger.info(f"Using builders {builder_names}")
+
     _convert_directory(
         input_directory=input_directory,
         output_directory=output_directory,
-        builders=builders if builders is not None else DEFAULT_IMAGE_BUILDERS,
+        builders=builders,
         consumed_files=consumed_files,
         new_images=new_images,
         new_image_files=new_image_files,
@@ -91,10 +99,21 @@ def _convert_directory(
         elif o.is_file():
             files.add(o)
 
+    logger.info(f"Converting directory {input_directory}")
+
     for builder in builders:
+        builder_files = files - consumed_files
+
+        if len(builder_files) == 0:
+            return
+
+        logger.debug(
+            f"Processing {len(builder_files)} file(s) with {builder.__name__}"
+        )
+
         builder_result = _build_files(
             builder=builder,
-            files=files - consumed_files,
+            files=builder_files,
             output_directory=output_directory,
         )
 
@@ -102,6 +121,14 @@ def _convert_directory(
         new_image_files |= builder_result.new_image_files
         new_folders |= builder_result.new_folders
         consumed_files |= builder_result.consumed_files
+
+        if builder_result.consumed_files:
+            logger.info(
+                f"{builder.__name__} created {len(builder_result.new_images)} "
+                f"new images(s) from {len(builder_result.consumed_files)} file(s)"
+            )
+        else:
+            logger.debug(f"No files consumed by {builder.__name__}")
 
         for filepath, errors in builder_result.file_errors.items():
             file_errors[filepath].extend(errors)
@@ -142,6 +169,8 @@ def _post_process(
 ) -> PostProcessorResult:
     new_image_files: Set[PanImgFile] = set()
     new_folders: Set[PanImgFolder] = set()
+
+    logger.info(f"Post processing {len(image_files)} image(s)")
 
     for processor in post_processors:
         result = processor(image_files=image_files)

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,10 +48,21 @@ python-versions = "*"
 pycparser = "*"
 
 [[package]]
+name = "click"
+version = "8.0.0"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -424,7 +435,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5de0cb9b7fae73146f4a65f789bf9d4af4f5afc5d5a86475f7e242a83140b509"
+content-hash = "cf4dc792608dc8e0522048030fb0e450118bbaa467552c3c5903f0cfb89f25c8"
 
 [metadata.files]
 apipkg = [
@@ -481,6 +492,10 @@ cffi = [
     {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
     {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
     {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
+]
+click = [
+    {file = "click-8.0.0-py3-none-any.whl", hash = "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"},
+    {file = "click-8.0.0.tar.gz", hash = "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 
+[tool.poetry.scripts]
+panimg = "panimg.cli:cli"
+
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic = "*"
@@ -54,6 +57,7 @@ Pillow = "*"
 openslide-python = "*"
 pyvips = "*"
 tifffile = "*"
+click = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
At the moment this produces a lot of warnings, but the basic functionality works.

#30 

```
(panimg-_ufyEygO-py3.8) james@gazelle:~/code/github.com/diagnijmegen/rse-panimg$ panimg convert tests/resources/ /tmp/test-cli/
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642090): Unsupported or empty metaData item ITK_FileNotes of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642090): Unsupported or empty metaData item aux_file of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642090): Unsupported or empty metaData item descrip of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642090): Unsupported or empty metaData item intent_name of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642650): Unsupported or empty metaData item ITK_FileNotes of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642650): Unsupported or empty metaData item aux_file of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642650): Unsupported or empty metaData item descrip of type Ssfound, won't be written to image file

WARNING: In /tmp/SimpleITK-build/ITK/Modules/IO/Meta/src/itkMetaImageIO.cxx, line 669
MetaImageIO (0x2642650): Unsupported or empty metaData item intent_name of type Ssfound, won't be written to image file

GDCM is unavailable, conversion of DICOM with compressed transfer syntax will fail to convert. To correct this, installGDCM.
Could not create DZI for PanImgFile(image_id=UUID('316adecb-ba0e-4447-813f-74a2f679b4aa'), image_type=<ImageType.TIFF: 'TIFF'>, file=
PosixPath('/tmp/test-cli/no_dzi.tif/316adecb-ba0e-4447-813f-74a2f679b4aa.tif')): unable to call dzsave
  TIFFFillTile: 0: Invalid tile byte count, tile 0
TIFFFillTile: 0: Invalid tile byte count, tile 1
TIFFFillTile: 0: Invalid tile byte count, tile 2
TIFFFillTile: 0: Invalid tile byte count, tile 3
TIFFFillTile: 0: Invalid tile byte count, tile 4
TIFFFillTile: 0: Invalid tile byte count, tile 5

(panimg-_ufyEygO-py3.8) james@gazelle:~/code/github.com/diagnijmegen/rse-panimg$ tree /tmp/test-cli/
/tmp/test-cli/
├── complex_tiff
│   ├── Hamamatsu-VMS
│   │   ├── CMU-1-40x - 2010-01-12 13.24.05(0,1).jpg
│   │   │   └── b12269fc-aaf7-4c3d-9843-1c34fdba77bd.mha
│   │   ├── CMU-1-40x - 2010-01-12 13.24.05(1,0).jpg
│   │   │   └── ad2681da-8465-4d63-8484-3311ff70dfbf.mha
│   │   ├── CMU-1-40x - 2010-01-12 13.24.05(1,1).jpg
│   │   │   └── 9aebba14-b4a9-4708-bebe-7796238864ce.mha
│   │   ├── CMU-1-40x - 2010-01-12 13.24.05.jpg
│   │   │   └── e7037388-0f9c-4c66-a31d-6a506ea91318.mha
│   │   ├── CMU-1-40x - 2010-01-12 13.24.05.opt
│   │   │   └── 28b48368-52ae-4e4d-9d17-fa28cc0bca19.mha
│   │   ├── CMU-1-40x - 2010-01-12 13.24.05_macro.jpg
│   │   │   └── 4b78d288-6eca-42d2-b1cc-a282fc3377ff.mha
│   │   └── CMU-1-40x - 2010-01-12 13.24.05_map2.jpg
│   │       └── aaff85ba-a6b4-4e31-8a71-7edbe330c412.mha
│   ├── Mirax2-Fluorescence-1
│   └── Mirax2-Fluorescence-1.mrxs
│       └── ca33f9da-357d-4eaa-8996-f244062ad019.mha
├── dicom
│   └── 1.1.1.1.1.1.11111.1.1.1.1111.1111.111111-0
│       └── 8b3cdae2-85bc-480a-acd8-12c5410d5614.mha
├── dicom_intercept
│   └── 1.1.1.1.1.1.11111.1.1.1.1111.1111.111111-0
│       └── 30a4ff60-fbff-474a-99d1-92c0fa81058e.mha
├── dicom_slope
│   └── 1.1.1.1.1.1.11111.1.1.1.1111.1111.111111-0
│       └── ed70521c-8ef4-4ccb-82fa-8c2420d8ba88.mha
├── dzi_tiff
│   └── valid_tiff.tif
│       ├── 906b0044-8201-4927-b5e3-06c4bb0cfb36.dzi
│       ├── 906b0044-8201-4927-b5e3-06c4bb0cfb36.tif
│       └── 906b0044-8201-4927-b5e3-06c4bb0cfb36_files
│           ├── 0
│           │   └── 0_0.jpeg
│           ├── 1
│           │   └── 0_0.jpeg
│           ├── 2
│           │   └── 0_0.jpeg
│           ├── 3
│           │   └── 0_0.jpeg
│           ├── 4
│           │   └── 0_0.jpeg
│           ├── 5
│           │   └── 0_0.jpeg
│           ├── 6
│           │   └── 0_0.jpeg
│           ├── 7
│           │   └── 0_0.jpeg
│           └── 8
│               └── 0_0.jpeg
├── image10x10x10-extra-stuff.mhd
│   └── f70ba331-1a7a-46d7-afac-e0696a62f527.mha
├── image10x10x10.mha
│   └── 964f9eba-4808-4e96-a994-559e7a6dc4fb.mha
├── image10x10x10.mhd
│   └── 74f5441c-952d-4e9e-a6a6-6f814ba0a4ae.mha
├── image10x11x12.nii
│   └── b5553fbd-7b46-4598-8b89-8dcc0c4c743f.mha
├── image10x11x12.nii.gz
│   └── d284f1d7-29fe-4e27-b7ca-6955ab323c6c.mha
├── image10x11x12x13-extra-stuff.mhd
│   └── 24996e93-86b9-4a6f-9225-15cd4b5c5be9.mha
├── image10x11x12x13.mha
│   └── 347fc442-5a31-4ef4-9b58-de6b0bbf4634.mha
├── image10x11x12x13.mhd
│   └── 707f680d-b3f3-4cb9-979c-dfeb9d83b86b.mha
├── image128x256RGB.mhd
│   └── 8d9ddf6f-d57f-4418-923a-6ed211370e8c.mha
├── image128x256x3RGB.mhd
│   └── 6b31f975-74f9-481f-acc3-4b53ca009ce1.mha
├── image128x256x4RGB.mhd
│   └── 706dba8f-ddab-4e7a-ac64-96dd69b01ef0.mha
├── image3x4-extra-stuff.mhd
│   └── 51f3c9aa-a55c-4ae1-a5fd-ee795dc8c389.mha
├── image3x4-no-spacing-with-12-size.mhd
│   └── 1ad78d39-41a6-4f97-ab83-b3f4a06900ba.mha
├── image3x4-no-spacing.mhd
│   └── 9e9bc1e0-80ab-41f5-8242-961b9a19396f.mha
├── image3x4-with-12-spacing.mhd
│   └── eab4d134-fc8f-42ed-b51c-ff7357d04efd.mha
├── image3x4.mhd
│   └── cfff11ec-7ee2-41b1-8b4a-ac436401b297.mha
├── image5x6x7-no-spacing-with-123-size.mhd
│   └── 0708ce50-b89d-4b5a-83bb-452152572a6c.mha
├── image5x6x7-no-spacing.mhd
│   └── 8c90e213-8307-42b6-8dce-669e31b5bd06.mha
├── image5x6x7-with-123-spacing.mhd
│   └── e9168d26-1dfb-4a1b-a85e-fc60f8fb3a12.mha
├── image5x6x7.mhd
│   └── cc6704b7-2881-4754-a0d9-7db344e739b8.mha
├── no_dzi.tif
│   ├── 316adecb-ba0e-4447-813f-74a2f679b4aa-6ITD30
│   └── 316adecb-ba0e-4447-813f-74a2f679b4aa.tif
├── test_grayscale.jpg
│   └── c659b96e-44b2-486e-bdd2-12b8cb3fd144.mha
├── test_grayscale.png
│   └── 16494366-ce24-4d2f-90bf-5a9511c56f4e.mha
├── test_rgb.jpg
│   └── 10f0bf9d-2287-4425-bbdb-ca92c9fd30b1.mha
├── test_rgb.png
│   └── c96e4423-95b3-4279-bfa1-94452a2716a2.mha
├── test_rgba.png
│   └── 532e47c3-2042-444a-a447-96eae3edfe6c.mha
└── valid_tiff.tif
    ├── bf3c54ae-5808-4b16-ad66-a63ff92b894c.dzi
    ├── bf3c54ae-5808-4b16-ad66-a63ff92b894c.tif
    └── bf3c54ae-5808-4b16-ad66-a63ff92b894c_files
        ├── 0
        │   └── 0_0.jpeg
        ├── 1
        │   └── 0_0.jpeg
        ├── 2
        │   └── 0_0.jpeg
        ├── 3
        │   └── 0_0.jpeg
        ├── 4
        │   └── 0_0.jpeg
        ├── 5
        │   └── 0_0.jpeg
        ├── 6
        │   └── 0_0.jpeg
        ├── 7
        │   └── 0_0.jpeg
        └── 8
            └── 0_0.jpeg

67 directories, 59 files
(panimg-_ufyEygO-py3.8) james@gazelle:~/code/github.com/diagnijmegen/rse-panimg$

```