### PR TITLE
Disable E2E OCT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ To access the help test you can use `panimg -h`.
 | `.dcm`                              | `.mha`  | `dicom`    | <sup>[1](#footnote1)</sup> |
 | `.nii`                              | `.mha`  | `nifti`    |                            |
 | `.nii.gz`                           | `.mha`  | `nifti`    |                            |
-| `.e2e`                              | `.mha`  | `oct`      | <sup>[2](#footnote2)</sup> |
 | `.fds`                              | `.mha`  | `oct`      | <sup>[2](#footnote2)</sup> |
 | `.fda`                              | `.mha`  | `oct`      | <sup>[2](#footnote2)</sup> |
 | `.png`                              | `.mha`  | `fallback` | <sup>[3](#footnote3)</sup> |
@@ -75,7 +74,7 @@ To access the help test you can use `panimg -h`.
 
 <a name="footnote1">1</a>: Compressed DICOM requires `gdcm`
 
-<a name="footnote2">2</a>: Both OCT volume(s) and fundus image(s) will be extracted.
+<a name="footnote2">2</a>: Only OCT volume(s), no fundus image(s) will be extracted.
 
 <a name="footnote3">3</a>: 2D only, unitary dimensions
 

--- a/panimg/image_builders/oct.py
+++ b/panimg/image_builders/oct.py
@@ -159,6 +159,9 @@ def _get_image(
             oct_slice_size,
         )
     elif file.suffix == ".e2e":
+        # support for E2E files is disabled until we have a proper E2E file to
+        # test with
+        raise ValueError
         e2e_img = E2E(file)
         # We were unable to retrieve slice size information from the e2e files.
         # The following default values are taken from:

--- a/panimg/image_builders/oct.py
+++ b/panimg/image_builders/oct.py
@@ -206,7 +206,7 @@ def image_builder_oct(*, files: Set[Path]) -> Iterator[SimpleITKImage]:
                 file=file,
                 oct_volumes=oct_volumes,
                 # Skip fundus_images until we decide how to handle these
-                fundus_images=[], # fundus_images,
+                fundus_images=[],  # fundus_images,
                 oct_slice_size=oct_slice_size,
             )
 

--- a/panimg/image_builders/oct.py
+++ b/panimg/image_builders/oct.py
@@ -205,7 +205,8 @@ def image_builder_oct(*, files: Set[Path]) -> Iterator[SimpleITKImage]:
             yield from _create_itk_images(
                 file=file,
                 oct_volumes=oct_volumes,
-                fundus_images=fundus_images,
+                # Skip fundus_images until we decide how to handle these
+                fundus_images=[], # fundus_images,
                 oct_slice_size=oct_slice_size,
             )
 

--- a/tests/test_default_image_builders.py
+++ b/tests/test_default_image_builders.py
@@ -63,7 +63,7 @@ def test_number_of_images_consumed_by_each_builder(tmp_path, builder):
     )
 
     if image_builder_oct == builder:
-        assert len(result.new_images) == 4
+        assert len(result.new_images) == 2
     else:
         assert len(result.new_images) == 1
     assert len(result.consumed_files) == len(files) - len(result.file_errors)

--- a/tests/test_default_image_builders.py
+++ b/tests/test_default_image_builders.py
@@ -53,7 +53,6 @@ def test_number_of_images_consumed_by_each_builder(tmp_path, builder):
         RESOURCE_PATH / "image10x10x10.mha",
         RESOURCE_PATH / "image10x11x12.nii.gz",
         RESOURCE_PATH / "valid_tiff.tif",
-        # RESOURCE_PATH / "oct/BRVO_O4003_baseline.e2e",
         RESOURCE_PATH / "oct/fda_minimized.fda",
         RESOURCE_PATH / "oct/fds_minimized.fds",
     }

--- a/tests/test_oct.py
+++ b/tests/test_oct.py
@@ -91,7 +91,7 @@ def test_image_builder_oct(
         expected_values = expected_oct_properties
         if "fundus" in result.name:
             # expected_values = expected_fundus_properties
-            continue # Skip fundus_images for now
+            continue  # Skip fundus_images for now
 
         for k, v in expected_values.items():
             assert getattr(result, k) == v

--- a/tests/test_oct.py
+++ b/tests/test_oct.py
@@ -16,8 +16,6 @@ from tests import RESOURCE_PATH
 @pytest.mark.parametrize(
     "src,expected_fundus_properties,expected_oct_properties",
     (
-        # TODO retrieve publicly usable E2E file and minimize it
-        # RESOURCE_PATH / "oct/BRVO_O4003_baseline.e2e",
         (
             # Minimized .fda OCT file was created by taking example OCT file at
             # biobank.ndph.ox.ac.uk/showcase/showcase/examples/eg_oct_fda.fda

--- a/tests/test_oct.py
+++ b/tests/test_oct.py
@@ -86,11 +86,12 @@ def test_image_builder_oct(
         )
 
     assert result.consumed_files == {dest}
-    assert len(result.new_images) == 2
+    assert len(result.new_images) == 1
     for result in result.new_images:
         expected_values = expected_oct_properties
         if "fundus" in result.name:
-            expected_values = expected_fundus_properties
+            # expected_values = expected_fundus_properties
+            continue # Skip fundus_images for now
 
         for k, v in expected_values.items():
             assert getattr(result, k) == v


### PR DESCRIPTION
No valid E2E test file can be retrieved so E2E support will be disabled for now.