### PR TITLE
Fix extra metadata defaults

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.5.1 (2021-10-04)
+
+* Fix default values for extra metadata fields
+
 ## 0.5.0 (2021-10-01)
 
 * Added extra metadata fields to PanImg object

--- a/panimg/__init__.py
+++ b/panimg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 import logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ commands =
 
 [tool.poetry]
 name = "panimg"
-version = "0.5.0"
+version = "0.5.1"
 description = "Conversion of medical images to MHA and TIFF."
 license = "Apache-2.0"
 authors = ["James Meakin <12661555+jmsmkn@users.noreply.github.com>"]

--- a/tests/test_panimg.py
+++ b/tests/test_panimg.py
@@ -2,4 +2,4 @@ from panimg import __version__
 
 
 def test_version():
-    assert __version__ == "0.5.0"
+    assert __version__ == "0.5.1"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,7 +62,7 @@ def test_convert_itk_to_internal(image: Path):
             if md.keyword in md_keys:
                 assert value == md.cast_func(img.GetMetaData(md.keyword))
             else:
-                assert value is None
+                assert value is md.default_value
 
     img_ref = load_sitk_image(image)
     internal_image = SimpleITKImage(


### PR DESCRIPTION
Default values for the extra metadata fields were set to `None` by default but grand challenge was expecting `""` for most of them. This PR sets them correctly and adds a test for it. Also bumps the patch version number in the files so a new release can be created.
Thanks @chrisvanrun for noticing!