### PR TITLE
Remove duplicate except clause

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.5.2 (2021-10-20)
+
+* Fix duplicate except clause
+
 ## 0.5.1 (2021-10-04)
 
 * Fix default values for extra metadata fields

--- a/panimg/__init__.py
+++ b/panimg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 import logging
 

--- a/panimg/image_builders/metaio_mhd_mha.py
+++ b/panimg/image_builders/metaio_mhd_mha.py
@@ -97,10 +97,6 @@ def image_builder_mhd(  # noqa: C901
 
             try:
                 simple_itk_image = load_sitk_image(file.absolute())
-            except ValidationError as e:
-                file_errors[file].append(
-                    format_error(f"Could not validate file. {e}")
-                )
             except RuntimeError:
                 file_errors[file].append(
                     format_error("SimpleITK could not open file.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ commands =
 
 [tool.poetry]
 name = "panimg"
-version = "0.5.1"
+version = "0.5.2"
 description = "Conversion of medical images to MHA and TIFF."
 license = "Apache-2.0"
 authors = ["James Meakin <12661555+jmsmkn@users.noreply.github.com>"]

--- a/tests/test_panimg.py
+++ b/tests/test_panimg.py
@@ -2,4 +2,4 @@ from panimg import __version__
 
 
 def test_version():
-    assert __version__ == "0.5.1"
+    assert __version__ == "0.5.2"


### PR DESCRIPTION
Due to a merge error there was a duplicate `except ValidationError` clause in the MetaIO builder, of which the first one did not contain the `continue` keyword. This PR removes it which should fix #55. 