### PR TITLE
Require at least numpy 1.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ panimg = "panimg.cli:cli"
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic = "*"
-numpy = "*"
+numpy = ">=1.20"
 SimpleITK = ">=2.0"
 pydicom = ">=2.2"
 Pillow = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ panimg = "panimg.cli:cli"
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic = "*"
-numpy = ">=1.20"
+numpy = ">=1.21"
 SimpleITK = ">=2.0"
 pydicom = ">=2.2"
 Pillow = "*"


### PR DESCRIPTION
The OCT builder uses `numpy.typing` ([here](https://github.com/DIAGNijmegen/rse-panimg/blob/main/panimg/image_builders/oct.py#L16)) which [has only been added in numpy 1.20](https://numpy.org/devdocs/reference/typing.html). The specific type that is used (`numpy.typing.NDArray`) [has been added in 1.21](https://numpy.org/devdocs/reference/typing.html#numpy.typing.NDArray).

This is currently especially relevant because in our standard docker base image, we are still using numpy 1.19.