### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-  python: python3.8
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
@@ -15,6 +13,10 @@ repos:
       - id: pyupgrade
         language: python
         args: [--py37-plus]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
   - repo: https://github.com/ambv/black
     rev: 22.1.0
     hooks:
@@ -27,7 +29,6 @@ repos:
         language: python
         additional_dependencies:
           - flake8-bugbear
-          - flake8-import-order
           - pep8-naming
           - flake8-docstrings
           - mccabe

--- a/panimg/contrib/oct_converter/image_types/__init__.py
+++ b/panimg/contrib/oct_converter/image_types/__init__.py
@@ -1,4 +1,4 @@
-from .oct import OCTVolumeWithMetaData
 from .fundus import FundusImageWithMetaData
+from .oct import OCTVolumeWithMetaData
 
 __all__ = ["OCTVolumeWithMetaData", "FundusImageWithMetaData"]

--- a/panimg/contrib/oct_converter/readers/__init__.py
+++ b/panimg/contrib/oct_converter/readers/__init__.py
@@ -1,5 +1,5 @@
-from .fds import FDS
 from .e2e import E2E
 from .fda import FDA
+from .fds import FDS
 
 __all__ = ["FDS", "E2E", "FDA"]

--- a/panimg/contrib/oct_converter/readers/e2e.py
+++ b/panimg/contrib/oct_converter/readers/e2e.py
@@ -1,13 +1,14 @@
 import re
 import struct
+from pathlib import Path
 
 import numpy as np
-from construct import PaddedString, Int16un, Struct, Int32sn, Int32un, Int8un
+from construct import Int8un, Int16un, Int32sn, Int32un, PaddedString, Struct
+
 from panimg.contrib.oct_converter.image_types import (
-    OCTVolumeWithMetaData,
     FundusImageWithMetaData,
+    OCTVolumeWithMetaData,
 )
-from pathlib import Path
 
 
 class E2E:

--- a/panimg/contrib/oct_converter/readers/fda.py
+++ b/panimg/contrib/oct_converter/readers/fda.py
@@ -1,11 +1,13 @@
-from construct import PaddedString, Struct, Int32un
-import numpy as np
-from panimg.contrib.oct_converter.image_types import (
-    OCTVolumeWithMetaData,
-    FundusImageWithMetaData,
-)
-from pylibjpeg import decode
 from pathlib import Path
+
+import numpy as np
+from construct import Int32un, PaddedString, Struct
+from pylibjpeg import decode
+
+from panimg.contrib.oct_converter.image_types import (
+    FundusImageWithMetaData,
+    OCTVolumeWithMetaData,
+)
 
 
 class FDA:

--- a/panimg/contrib/oct_converter/readers/fds.py
+++ b/panimg/contrib/oct_converter/readers/fds.py
@@ -1,10 +1,12 @@
-from construct import PaddedString, Struct, Int32un
-import numpy as np
-from panimg.contrib.oct_converter.image_types import (
-    OCTVolumeWithMetaData,
-    FundusImageWithMetaData,
-)
 from pathlib import Path
+
+import numpy as np
+from construct import Int32un, PaddedString, Struct
+
+from panimg.contrib.oct_converter.image_types import (
+    FundusImageWithMetaData,
+    OCTVolumeWithMetaData,
+)
 
 
 class FDS:

--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -4,9 +4,9 @@ from math import isclose
 from pathlib import Path
 from typing import DefaultDict, Iterator, List, Set
 
-import SimpleITK
 import numpy as np
 import pydicom
+import SimpleITK
 
 from panimg.exceptions import UnconsumedFilesException
 from panimg.models import (

--- a/panimg/image_builders/fallback.py
+++ b/panimg/image_builders/fallback.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import DefaultDict, Iterator, List, Set
 
-import SimpleITK
 import numpy as np
+import SimpleITK
 from PIL import Image
 from PIL.Image import DecompressionBombError
 

--- a/panimg/image_builders/oct.py
+++ b/panimg/image_builders/oct.py
@@ -11,9 +11,9 @@ from typing import (
     Union,
 )
 
-import SimpleITK
 import numpy as np
 import numpy.typing as npt
+import SimpleITK
 from construct.core import Float64l, Int8ul, PaddedString, StreamError, Struct
 from pydantic import BaseModel
 

--- a/panimg/models.py
+++ b/panimg/models.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple
 from uuid import UUID, uuid4
 
-from SimpleITK import Image, WriteImage
 from pydantic import BaseModel, validator
 from pydantic.dataclasses import dataclass
+from SimpleITK import Image, WriteImage
 
 from panimg.exceptions import ValidationError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ pytest-cov = "*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+profile = "black"
+known_first_party = ["panimg", "tests"]
+line_length = 79
+
 [tool.black]
 line-length = 79
 target-version = ['py37']

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,10 +24,6 @@ warn_untyped_fields = True
 
 [flake8]
 max-line-length = 79
-application-import-names =
-    tests
-    panimg
-import-order-style = pycharm
 docstring-convention = numpy
 max-complexity = 10
 select =

--- a/tests/test_mhd.py
+++ b/tests/test_mhd.py
@@ -3,8 +3,8 @@ import zlib
 from pathlib import Path
 from typing import List, Union
 
-import SimpleITK
 import pytest
+import SimpleITK
 
 from panimg.exceptions import ValidationError
 from panimg.image_builders.metaio_utils import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
-import SimpleITK
 import pytest
+import SimpleITK
 from pytest import approx
 
 from panimg.image_builders.metaio_utils import load_sitk_image
-from panimg.models import ColorSpace, EXTRA_METADATA, SimpleITKImage
+from panimg.models import EXTRA_METADATA, ColorSpace, SimpleITKImage
 from tests import RESOURCE_PATH
 
 


### PR DESCRIPTION
This PR adds isort with the following changes:

- [x] `default_language_version` removed
- [x] pyupgrade args set correctly
- [x] `isort` added before `black`
- [x] `flake8-import-order` removed
- [x] `known_first_party` set correctly
- [x] `application-import-names` and `import-order-style` removed