### PR TITLE
Adds photometric interpretation dicom-tag as pass through for DICOMs.

### DIFF
--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -37,6 +37,13 @@ OPTIONAL_METADATA_FIELDS = (
     "SliceThickness",
     "WindowCenter",
     "WindowWidth",
+    "PhotometricInterpretation",
+    "RedPaletteColorLookupTableData",
+    "RedPaletteColorLookupTableDescriptor",
+    "GreenPaletteColorLookupTableData",
+    "GreenPaletteColorLookupTableDescriptor",
+    "BluePaletteColorLookupTableData",
+    "BluePaletteColorLookupTableDescriptor",
     *[md.keyword for md in EXTRA_METADATA],
 )
 

--- a/tests/resources/image3x4-extra-stuff.mhd
+++ b/tests/resources/image3x4-extra-stuff.mhd
@@ -26,6 +26,7 @@ PatientBirthDate = 20200101
 PatientAge = 001Y
 PatientSex = M
 Laterality = R
+PhotometricInterpretation = MONOCHROME1
 StudyDescription = super awesome study
 SeriesDescription = super awesome series
 SliceThickness = 2


### PR DESCRIPTION
See title.

Related to:
- https://github.com/DIAGNijmegen/rse-cirrus-core/pull/1799