### PR TITLE
Make 'MONOCHROME1' photometric interpretation content dependent

### DIFF
--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -111,6 +111,10 @@ class DicomDataset:
                 else:
                     yield np.array(file_origin, dtype=float)
 
+    @staticmethod
+    def _invert_intensities(array: np.ndarray) -> np.ndarray:
+        return -array + array.max() + array.min()
+
     def _determine_slice_order(self):
         # Compute coordinate differences between successive slices
         origin = None
@@ -268,10 +272,7 @@ class DicomDataset:
             self.ref_header, "PhotometricInterpretation", None
         )
         if not is_rgb and photometric_interpretation == "MONOCHROME1":
-            if np.issubdtype(dcm_array.dtype, np.floating):
-                dcm_array = -dcm_array
-            else:
-                dcm_array = ~dcm_array
+            dcm_array = self._invert_intensities(dcm_array)
 
         return SimpleITK.GetImageFromArray(dcm_array, isVector=is_rgb)
 


### PR DESCRIPTION
Switches to MONOCHROME1 interpretation using the actual min and max values to invert around.

For good measure I've added the most minimum of unit test wrapping a singular function.