### PR TITLE
Group DICOM files differently

### DIFF
--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -363,7 +363,7 @@ def _get_headers_by_study(
     A dictionary of sorted headers for all dicom image files found within path,
     grouped by study id.
     """
-    study_key = Tuple[Any, Any, Any]
+    study_key = Tuple[str, str, str]
     studies: Dict[study_key, Dict[str, Any]] = {}
     indices: Dict[str, Dict[study_key, int]] = {}
 

--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -363,9 +363,9 @@ def _get_headers_by_study(
     A dictionary of sorted headers for all dicom image files found within path,
     grouped by study id.
     """
-    study_key = Tuple[str, str, str]
-    studies: Dict[study_key, Dict[str, Any]] = {}
-    indices: Dict[str, Dict[study_key, int]] = {}
+    study_key_type = Tuple[str, ...]
+    studies: Dict[study_key_type, Dict[str, Any]] = {}
+    indices: Dict[str, Dict[study_key_type, int]] = {}
 
     for file in files:
         if not file.is_file():
@@ -379,7 +379,7 @@ def _get_headers_by_study(
                 # Additionally also group by SOP class UID to skip over extra
                 # raw data (dose reports for example) that are sometimes stored
                 # under the same series instance UID.
-                key: study_key = (
+                key: study_key_type = (
                     ds.StudyInstanceUID,
                     getattr(ds, "StackID", ds.SeriesInstanceUID),
                     ds.SOPClassUID,

--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -396,7 +396,7 @@ def _get_headers_by_study(
                 try:
                     index = indices[ds.StudyInstanceUID][key]
                 except KeyError:
-                    index = len(indices[ds.StudyInstanceUID]) + 1
+                    index = len(indices[ds.StudyInstanceUID])
                     indices[ds.StudyInstanceUID][key] = index
 
                 headers = studies[key].get("headers", [])

--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -363,8 +363,9 @@ def _get_headers_by_study(
     A dictionary of sorted headers for all dicom image files found within path,
     grouped by study id.
     """
-    studies: Dict[Any, Dict[str, Any]] = {}
-    indices: Dict[Any, Dict[Any, int]] = {}
+    study_key = Tuple[Any, Any, Any]
+    studies: Dict[study_key, Dict[str, Any]] = {}
+    indices: Dict[str, Dict[study_key, int]] = {}
 
     for file in files:
         if not file.is_file():
@@ -378,7 +379,7 @@ def _get_headers_by_study(
                 # Additionally also group by SOP class UID to skip over extra
                 # raw data (dose reports for example) that are sometimes stored
                 # under the same series instance UID.
-                key = (
+                key: study_key = (
                     ds.StudyInstanceUID,
                     getattr(ds, "StackID", ds.SeriesInstanceUID),
                     ds.SOPClassUID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ numpy = [
   { version = "^1.21", python = "<3.8" },
   { version = "^1.22", python = ">=3.8,<3.10" }
 ]
-SimpleITK = ">=2.0"
+# Exclude 2.1.1.1 due to
+# https://github.com/SimpleITK/SimpleITK/issues/1627
+# and https://github.com/python-poetry/poetry/issues/2453
+SimpleITK = ">=2.0,!=2.1.1.1"
 pydicom = ">=2.2"
 Pillow = "*"
 openslide-python = "*"

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -50,7 +50,7 @@ def test_validate_dicom_files():
     with mock.patch(
         "panimg.image_builders.dicom._get_headers_by_study",
         return_value={
-            "foo": {"headers": headers[1:], "file": "bar", "index": 1}
+            "foo": {"headers": headers[1:], "name": "StudyInstanceUID-0"}
         },
     ):
         errors = defaultdict(list)


### PR DESCRIPTION
The DICOM image builder groups the individual files currently by study instance UID and in-plane dimensions of the image. It does that instead of just using the series instance UID because the individual 3D frames of a 4D volumes have different series instance UIDs. But this is clearly not ideal, there is no reason that there could not be two series with the same dimensions in the same study. This PR changes this to either use the StackID (mandatory DICOM tag in 4D images) or the series instance UID otherwise.

Additionally, I've come across a dataset where some additional reconstruction parameters were stored under the same series instance UID but with a different SOP class UID. This made the image builder crash. To fix this, this PR also adds the SOP class UID to the variables that identify a single image. The builder will then only crash for the non-image file and will work fine for the image itself.