### PR TITLE
Fix delayed warning about missing OpenSlide installation on Windows

### DIFF
--- a/panimg/image_builders/tiff.py
+++ b/panimg/image_builders/tiff.py
@@ -14,7 +14,7 @@ from panimg.models import ColorSpace, TIFFImage
 
 try:
     import openslide
-except OSError:
+except (OSError, ModuleNotFoundError):
     openslide = False
 
 try:


### PR DESCRIPTION
openslide-python now raises a `ModuleNotFoundError` when the module is imported but fails to open the OpenSlide DLL on Windows. This used to result in a `FileNotFoundError`, which is caught in panimg to enable using the library without an OpenSlide installation.

See https://github.com/openslide/openslide-python/commit/2e6d06a564eeccbad2892b39961d21ad32d9cbd5

openslide-python catches these errors only on Windows and Mac OS, so I think we still need to catch OSErrors in case the library is not installed on Linux.