### PR TITLE
Correct how the number of timepoints in a 4D scan is determined

### DIFF
--- a/panimg/image_builders/dicom.py
+++ b/panimg/image_builders/dicom.py
@@ -471,9 +471,12 @@ def _find_valid_dicom_files(
             continue
 
         n_files = len(headers)
-        n_time = max(
-            int(getattr(header["data"], "TemporalPositionIndex", 0))
-            for header in headers
+        n_time = len(
+            {
+                int(header["data"].TemporalPositionIndex)
+                for header in headers
+                if "TemporalPositionIndex" in header["data"]
+            }
         )
 
         arbitrary_header = headers[0]["data"]
@@ -487,8 +490,8 @@ def _find_valid_dicom_files(
             )
         n_slices = n_files * n_slices_per_file
 
-        if n_time < 1:
-            # Not a 4d dicom file (DICOM standard says TPI is >=1 )
+        if n_time < 2:
+            # Not a 4d dicom file
             result.append(
                 DicomDataset(
                     name=set_name,


### PR DESCRIPTION
The DICOM reader was not working properly for reading a single timepoint of a 4D scan. It would crash when the TemporalPositionIndex is 3 but the data of timepoints 1 and 2 are not present because we are not trying to read the entire 4D sequence but only one 3D image from the sequence. This PR changes the logic to counting the number of distinct TemporalPositionIndex values instead of using the maximum value.