### PR TITLE
Remove usage of `PanImgFolder`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.11.0 (2023-03-07)
+
+* Removes `PanImgFolder` and outputs of `new_folders`, instead `directory` is added to `PanImgFile`
+
 ## 0.10.0 (2023-03-03)
 
 * Removed support for Python 3.7

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Under the hood we use:
 
 ## Usage
 
-`panimg` takes a folder and tries to convert the containing files to MHA or TIFF.
+`panimg` takes a directory and tries to convert the containing files to MHA or TIFF.
 By default, it will try to convert files from subdirectories as well.
 To only convert files in the top level directory, set `recurse_subdirectories` to `False`.
-It will try several strategies for loading the contained files, and if an image is found it will output it to the output folder.
+It will try several strategies for loading the contained files, and if an image is found it will output it to the output directory.
 It will return a structure containing information about what images were produced, what images were used to form the new images, image metadata, and any errors from any of the strategies.
 
 
-**NOTE: Alpha software, do not run this on folders you do not have a backup of.**
+**NOTE: Alpha software, do not run this on directories you do not have a backup of.**
 
 ```python
 from pathlib import Path
@@ -48,7 +48,7 @@ result = convert(
 `panimg` is also accessible from the command line.
 Install the package from pip as before, then you can use:
 
-**NOTE: Alpha software, do not run this on folders you do not have a backup of.**
+**NOTE: Alpha software, do not run this on directories you do not have a backup of.**
 
 ```shell
 panimg convert /path/to/files/ /where/files/will/go/

--- a/panimg/image_builders/metaio_mhd_mha.py
+++ b/panimg/image_builders/metaio_mhd_mha.py
@@ -49,7 +49,7 @@ def image_builder_mhd(  # noqa: C901
         if path not in data_file_path.parents:
             raise ValueError(
                 f"{element_data_file_key} references a file which is not in "
-                f"the uploaded data folder"
+                f"the uploaded data directory"
             )
         if not data_file_path.is_file():
             raise ValueError("Data container of mhd file is missing")

--- a/panimg/models.py
+++ b/panimg/models.py
@@ -163,19 +163,13 @@ class PanImgFile:
     image_id: UUID
     image_type: ImageType
     file: Path
-
-
-@dataclass(frozen=True)
-class PanImgFolder:
-    image_id: UUID
-    folder: Path
+    directory: Optional[Path] = None
 
 
 @dataclass
 class PanImgResult:
     new_images: Set[PanImg]
     new_image_files: Set[PanImgFile]
-    new_folders: Set[PanImgFolder]
     consumed_files: Set[Path]
     file_errors: Dict[Path, List[str]]
 
@@ -183,7 +177,6 @@ class PanImgResult:
 @dataclass
 class PostProcessorResult:
     new_image_files: Set[PanImgFile]
-    new_folders: Set[PanImgFolder]
 
 
 class SimpleITKImage(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "panimg"
-version = "0.10.0"
+version = "0.11.0"
 description = "Conversion of medical images to MHA and TIFF."
 license = "Apache-2.0"
 authors = ["James Meakin <panimg@jmsmkn.com>"]

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -191,21 +191,21 @@ def test_image_builder_dicom_4d_enhanced():
 
 
 @pytest.mark.parametrize(
-    "folder,element_type",
+    "directory,element_type",
     [
         ("dicom_4d", "MET_SHORT"),
         ("dicom_intercept", "MET_FLOAT"),
         ("dicom_slope", "MET_FLOAT"),
     ],
 )
-def test_dicom_rescaling(folder, element_type, tmpdir):
+def test_dicom_rescaling(directory, element_type, tmpdir):
     """
     2.dcm in dicom_intercept and dicom_slope has been modified to add a
     small intercept (0.01) or slope (1.001) respectively.
     """
     files = [
         Path(d[0]).joinpath(f)
-        for d in os.walk(RESOURCE_PATH / folder)
+        for d in os.walk(RESOURCE_PATH / directory)
         for f in d[2]
     ]
     result = _build_files(

--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -158,7 +158,7 @@ def test_load_with_tiff(
     source_dir, filename, expected_error_message, tmpdir_factory
 ):
     error_message = ""
-    # Copy resource file to writable temp folder
+    # Copy resource file to writable temp directory
     temp_file = Path(tmpdir_factory.mktemp("temp") / filename)
     shutil.copy(source_dir / filename, temp_file)
     gc_file = GrandChallengeTiffFile(temp_file)
@@ -178,7 +178,7 @@ def test_load_with_tiff(
     [(RESOURCE_PATH, "valid_tiff.tif"), (RESOURCE_PATH, "no_dzi.tif")],
 )
 def test_load_with_open_slide(source_dir, filename, tmpdir_factory):
-    # Copy resource file to writable temp folder
+    # Copy resource file to writable temp directory
     temp_file = Path(tmpdir_factory.mktemp("temp") / filename)
     shutil.copy(source_dir / filename, temp_file)
     gc_file = GrandChallengeTiffFile(temp_file)
@@ -231,7 +231,7 @@ def test_tiff_image_entry_creation(
 
 # Integration test of all features being accessed through the image builder
 def test_image_builder_tiff(tmpdir_factory):
-    # Copy resource files to writable temp folder
+    # Copy resource files to writable temp directory
     temp_dir = Path(tmpdir_factory.mktemp("temp") / "resources")
     output_dir = Path(tmpdir_factory.mktemp("output"))
 
@@ -263,7 +263,7 @@ def test_image_builder_tiff(tmpdir_factory):
 
 
 def test_handle_complex_files(tmpdir_factory):
-    # Copy resource files to writable temp folder
+    # Copy resource files to writable temp directory
     temp_dir = Path(tmpdir_factory.mktemp("temp") / "resources")
     shutil.copytree(RESOURCE_PATH / "complex_tiff", temp_dir)
     files = [Path(d[0]).joinpath(f) for d in os.walk(temp_dir) for f in d[2]]
@@ -327,7 +327,7 @@ def test_convert_to_tiff(resource, tmpdir_factory):
 
 
 def test_error_handling(tmpdir_factory):
-    # Copy resource files to writable temp folder
+    # Copy resource files to writable temp directory
     # The content files are dummy files and won't compile to tiff.
     # The point is to test the loading of gc_files and make sure all
     # related files are associated with the gc_file

--- a/tests/test_tiff_to_dzi.py
+++ b/tests/test_tiff_to_dzi.py
@@ -30,18 +30,12 @@ def test_dzi_creation(tmpdir_factory):
     assert (
         new_file.file == image_file.file.parent / f"{image_file.image_id}.dzi"
     )
-
-    assert len(result.new_folders) == 1
-
-    new_folder = result.new_folders.pop()
-
-    assert new_folder.image_id == image_file.image_id
     assert (
-        new_folder.folder
+        new_file.directory
         == image_file.file.parent / f"{image_file.image_id}_files"
     )
 
-    assert len(list((new_folder.folder).rglob("*.jpeg"))) == 9
+    assert len(list((new_file.directory).rglob("*.jpeg"))) == 9
 
 
 def test_no_exception_when_failed(tmpdir_factory, caplog):
@@ -57,7 +51,6 @@ def test_no_exception_when_failed(tmpdir_factory, caplog):
     result = tiff_to_dzi(image_files={image_file})
 
     assert len(result.new_image_files) == 0
-    assert len(result.new_folders) == 0
 
     # The last warning should be from our logger
     last_log = caplog.records[-1]


### PR DESCRIPTION
All folders must be associated with a file (in our only case: jpegs must be associated with a DZI file). This PR removes the `PanImgFolder` model and replaces it with an optional `directory` attribute on `PanImgFile`.