### PR TITLE
Fix issues with dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions poetry 'urllib3<2'
-        # Pinned version of urllib3 mitigates the issue described here: https://github.com/ionrock/cachecontrol/issues/292
+          python -m pip install 'tox>=4.4' 'tox-gh-actions>=3.1' 'poetry>=1.4'
       - name: Test with tox
         run: |
           tox


### PR DESCRIPTION
There is currently a clash between Tox and Poetry:

```
    tox 4.5.0 depends on platformdirs>=3.2
    poetry 1.4.2 depends on platformdirs<3.0.0 and >=2.5.2
    tox 4.5.0 depends on platformdirs>=3.2
    poetry 1.4.1 depends on platformdirs<3.0.0 and >=2.5.2
    tox 4.5.0 depends on platformdirs>=3.2
    poetry 1.4.0 depends on platformdirs<3.0.0 and >=2.5.2
```