### PR TITLE
Fix potential memory leaks by confining use of pyvips to subprocesses

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,10 @@
 # History
 
-## 0.15.0 (2024-01-06)
+## 0.15.1 (2025-01-23)
+
+* Fix potential memory leaks by confining use of `pyvips` to subprocesses
+
+## 0.15.0 (2025-01-06)
 
 * Removed support for Python 3.9
 

--- a/panimg/image_builders/tiff.py
+++ b/panimg/image_builders/tiff.py
@@ -2,12 +2,12 @@ import os
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterator
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import DefaultDict
 from uuid import UUID, uuid4
-from concurrent.futures import ProcessPoolExecutor
 
 import tifffile
 
@@ -337,9 +337,12 @@ def _convert(
 
             # If this is a globally importable value like "pyvips",
             # we ship it as string and look it up in _convert_to_tiff
-            # otherwise we pass the value directly
+            # otherwise we pass the value directly so that it can be
+            # used in the subprocess with proper resource isolation
             if converter in globals().values():
-                serialized_converter = [k for k, v in globals().items() if v == converter].pop()
+                serialized_converter = [
+                    k for k, v in globals().items() if v == converter
+                ].pop()
             else:
                 serialized_converter = converter
 

--- a/panimg/post_processors/tiff_to_dzi.py
+++ b/panimg/post_processors/tiff_to_dzi.py
@@ -1,9 +1,8 @@
 import logging
+from concurrent.futures import ProcessPoolExecutor
 
 from panimg.models import ImageType, PanImgFile, PostProcessorResult
 from panimg.settings import DZI_TILE_SIZE
-
-from concurrent.futures import ProcessPoolExecutor
 
 try:
     import pyvips
@@ -28,7 +27,9 @@ def tiff_to_dzi(*, image_files: set[PanImgFile]) -> PostProcessorResult:
         if file.image_type == ImageType.TIFF:
             try:
                 with ProcessPoolExecutor(max_workers=1) as executor:
-                    result = executor.submit(_create_dzi_image, tiff_file=file).result()
+                    result = executor.submit(
+                        _create_dzi_image, tiff_file=file
+                    ).result()
             except Exception as e:
                 logger.warning(f"Could not create DZI for {file}: {e}")
                 continue

--- a/panimg/post_processors/tiff_to_dzi.py
+++ b/panimg/post_processors/tiff_to_dzi.py
@@ -3,6 +3,8 @@ import logging
 from panimg.models import ImageType, PanImgFile, PostProcessorResult
 from panimg.settings import DZI_TILE_SIZE
 
+from concurrent.futures import ProcessPoolExecutor
+
 try:
     import pyvips
 except OSError:
@@ -25,7 +27,8 @@ def tiff_to_dzi(*, image_files: set[PanImgFile]) -> PostProcessorResult:
     for file in image_files:
         if file.image_type == ImageType.TIFF:
             try:
-                result = _create_dzi_image(tiff_file=file)
+                with ProcessPoolExecutor(max_workers=1) as executor:
+                    result = executor.submit(_create_dzi_image, tiff_file=file).result()
             except Exception as e:
                 logger.warning(f"Could not create DZI for {file}: {e}")
                 continue

--- a/panimg/post_processors/tiff_to_dzi.py
+++ b/panimg/post_processors/tiff_to_dzi.py
@@ -4,23 +4,10 @@ from concurrent.futures import ProcessPoolExecutor
 from panimg.models import ImageType, PanImgFile, PostProcessorResult
 from panimg.settings import DZI_TILE_SIZE
 
-try:
-    import pyvips
-except OSError:
-    pyvips = False
-
 logger = logging.getLogger(__name__)
 
 
 def tiff_to_dzi(*, image_files: set[PanImgFile]) -> PostProcessorResult:
-    if pyvips is False:
-        raise ImportError(
-            f"Could not import pyvips, which is required for the "
-            f"{__name__} post processor. Either ensure that libvips-dev "
-            f"is installed or remove {__name__} from your list of post "
-            f"processors."
-        )
-
     new_image_files: set[PanImgFile] = set()
 
     for file in image_files:
@@ -40,6 +27,8 @@ def tiff_to_dzi(*, image_files: set[PanImgFile]) -> PostProcessorResult:
 
 
 def _create_dzi_image(*, tiff_file: PanImgFile) -> PostProcessorResult:
+    import pyvips
+
     # Creates a dzi file and corresponding tiles in directory {pk}_files
     dzi_output = tiff_file.file.parent / str(tiff_file.image_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "panimg"
-version = "0.15.0"
+version = "0.15.1"
 description = "Conversion of medical images to MHA and TIFF."
 license = "Apache-2.0"
 authors = ["James Meakin <panimg@jmsmkn.com>"]

--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -324,7 +324,6 @@ def test_handle_complex_files(tmpdir_factory):
     _convert(
         files=files,
         associated_files_getter=_get_mrxs_files,
-        converter=mock_converter,
         output_directory=Path(tmpdir_factory.mktemp("output")),
         file_errors=defaultdict(list),
     )

--- a/tests/test_tiff.py
+++ b/tests/test_tiff.py
@@ -1,12 +1,9 @@
 import os
 import shutil
-from collections import defaultdict
 from pathlib import Path
-from unittest.mock import MagicMock, Mock
 from uuid import uuid4
 
 import pytest
-import pyvips
 import tifffile as tiff_lib
 from pytest import approx
 from tifffile import tifffile
@@ -14,10 +11,8 @@ from tifffile import tifffile
 from panimg.exceptions import ValidationError
 from panimg.image_builders.tiff import (
     GrandChallengeTiffFile,
-    _convert,
     _extract_tags,
     _get_color_space,
-    _get_mrxs_files,
     _load_with_openslide,
     _load_with_tiff,
     image_builder_tiff,
@@ -302,40 +297,6 @@ def test_image_builder_tiff(tmpdir_factory):
     assert len(image_builder_result.new_image_files) == 3
 
 
-def test_handle_complex_files(tmpdir_factory):
-    # Copy resource files to writable temp directory
-    temp_dir = Path(tmpdir_factory.mktemp("temp") / "resources")
-    shutil.copytree(RESOURCE_PATH / "complex_tiff", temp_dir)
-    files = [Path(d[0]).joinpath(f) for d in os.walk(temp_dir) for f in d[2]]
-
-    # set up mock object to mock pyvips
-    properties = {
-        "xres": 1,
-        "yres": 1,
-        "openslide.mpp-x": 0.2525,
-        "openslide.mpp-y": 0.2525,
-    }
-
-    mock_converter = MagicMock(pyvips)
-    mock_image = mock_converter.Image.new_from_file.return_value
-    mock_image.get = Mock(return_value=1)
-    mock_image.get_fields = Mock(return_value=properties)
-
-    _convert(
-        files=files,
-        associated_files_getter=_get_mrxs_files,
-        output_directory=Path(tmpdir_factory.mktemp("output")),
-        file_errors=defaultdict(list),
-    )
-
-    if pyvips.base.version(0) == 8 and pyvips.base.version(1) < 10:
-        # work-around calculation of xres and yres in _convert_to_tiff function
-        mock_image.copy.assert_called()
-        assert "xres" in mock_image.copy.call_args[1]
-    else:
-        mock_image.copy.assert_not_called()
-
-
 @pytest.mark.xfail(
     reason="skip for now as we don't want to upload a large testset"
 )
@@ -380,4 +341,94 @@ def test_error_handling(tmpdir_factory):
         output_directory=Path(tmpdir_factory.mktemp("output")),
     )
 
-    assert len(image_builder_result.file_errors) == 14
+    output = {k.name: v for k, v in image_builder_result.file_errors.items()}
+
+    assert output == {
+        "Mirax2-Fluorescence-1.mrxs": [
+            "TIFF image builder: Could not convert file to TIFF: "
+            "Mirax2-Fluorescence-1.mrxs, "
+            "error:unable to call VipsForeignLoadOpenslideFile\n  "
+            "openslide2vips: opening slide: "
+            "Index.dat doesn't have expected version\n",
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05.vms": [
+            "TIFF image builder: Could not convert file to TIFF: "
+            "CMU-1-40x - 2010-01-12 13.24.05.vms, "
+            "error:unable to call VipsForeignLoadOpenslideFile\n  "
+            "openslide2vips: opening slide: Can't validate JPEG 0: "
+            "No restart markers\n",
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "Data0001.dat": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "Index.dat": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05(0,1).jpg": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05_map2.jpg": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "Slidedat.ini": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05_macro.jpg": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05.opt": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05(1,0).jpg": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "Data0000.dat": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05.jpg": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "CMU-1-40x - 2010-01-12 13.24.05(1,1).jpg": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+        "Data0002.dat": [
+            "TIFF image builder: Could not open file with tifffile.",
+            "TIFF image builder: Could not open file with OpenSlide.",
+            "TIFF image builder: Validation error: "
+            "Not a valid tif: Image width could not be determined.",
+        ],
+    }


### PR DESCRIPTION
Calls to `libvips` that cause errors are suspected to cause memory leaks in libvips. In order to prevent this, this PR confines calls to pyvips to subprocesses spawned using `ProcessPoolExecutor`.