### PR TITLE
Increases the number of supported segmentations from 64 -> 127

### DIFF
--- a/panimg/models.py
+++ b/panimg/models.py
@@ -72,7 +72,8 @@ DICOM_VR_TO_VALUE_CAST = {
 
 # NOTE: Only int8 or uint8 data types are checked for segments
 # so the true maximum is 256
-MAXIMUM_SEGMENTS_LENGTH = 64
+# to avoid int8 overflow issues the value is set to 127 instead of 128
+MAXIMUM_SEGMENTS_LENGTH = 127
 
 
 class ExtraMetaData(NamedTuple):


### PR DESCRIPTION
Closes #119

This PR addresses issue #119 and sets the new maximum number of segmentations to 127. The solution to this problem seemed straightforward, so I created it. 

I realize this PR requires more work, such as testing whether the changes work with GC, but it appears to me that someone on the RSE team can do this in less than a few hours. Also, if there is a desire for PR-related tests for panimg, I would be willing to add these. 

**Caveats**
* 127 was picked as a maximum instead of 128 to address potential overflow issues with int8 segmentation types (as suggested by Paul)
* I couldn't find any tests in `test_models.py that check anything related to the maximum number of allowed segmentations.

